### PR TITLE
增加括号来修复非指针对象用SUPPER_PTR访问父类时，因优先级发生的错误

### DIFF
--- a/demo/Animal/lw_oopc.h
+++ b/demo/Animal/lw_oopc.h
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2008,2009,2010 by Tom Kao & MISOO Team & Yonghua Jin. All rights reserved.
+// Copyright (C) 2008,2009,2010 by Tom Kao & MISOO Team & Yonghua Jin. All rights reserved.
 // Released under the terms of the GNU Library or Lesser General Public License (LGPL).
 // Author: Tom Kao(中文名：高焕堂)，MISOO团队，Yonghua Jin(中文名：金永华)
 //
@@ -151,7 +151,7 @@ void type##_ctor(type* cthis) {
 
 #define EXTENDS(type)		struct type type
 
-#define SUPER_PTR(cthis, father) ((father*)(&(cthis->father)))
+#define SUPER_PTR(cthis, father) ((father*)(&((cthis)->father)))
 
 #define SUPER_PTR_2(cthis, father, grandfather) \
 	SUPER_PTR(SUPER_PTR(cthis, father), grandfather)
@@ -171,6 +171,6 @@ void type##_ctor(type* cthis) {
 #define SUB_PTR_3(selfptr, self, child, grandchild, greatgrandchild) \
 	SUB_PTR(SUB_PTR_2(selfptr, self, child, grandchild), grandchild, greatgrandchild)
 
-#define INHERIT_FROM(father, cthis, field)	cthis->father.field
+#define INHERIT_FROM(father, cthis, field)	(cthis)->father.field
 
 #endif

--- a/demo/Expr/lw_oopc.h
+++ b/demo/Expr/lw_oopc.h
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2008,2009,2010 by Tom Kao & MISOO Team & Yonghua Jin. All rights reserved.
+// Copyright (C) 2008,2009,2010 by Tom Kao & MISOO Team & Yonghua Jin. All rights reserved.
 // Released under the terms of the GNU Library or Lesser General Public License (LGPL).
-// Author: Tom Kao(中文名：高焕堂)，MISOO团队，Yonghua Jin(中文名：金永华)
+// Author: Tom Kao(中文名：高焕堂)，MISOO 团队，Yonghua Jin(中文名：金永华)
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -151,7 +151,7 @@ void type##_ctor(type* cthis) {
 
 #define EXTENDS(type)		struct type type
 
-#define SUPER_PTR(cthis, father) ((father*)(&(cthis->father)))
+#define SUPER_PTR(cthis, father) ((father*)(&((cthis)->father)))
 
 #define SUPER_PTR_2(cthis, father, grandfather) \
 	SUPER_PTR(SUPER_PTR(cthis, father), grandfather)
@@ -171,6 +171,6 @@ void type##_ctor(type* cthis) {
 #define SUB_PTR_3(selfptr, self, child, grandchild, greatgrandchild) \
 	SUB_PTR(SUB_PTR_2(selfptr, self, child, grandchild), grandchild, greatgrandchild)
 
-#define INHERIT_FROM(father, cthis, field)	cthis->father.field
+#define INHERIT_FROM(father, cthis, field)	(cthis)->father.field
 
 #endif

--- a/demo/expr-advance/lw_oopc.h
+++ b/demo/expr-advance/lw_oopc.h
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2008,2009,2010 by Tom Kao & MISOO Team & Yonghua Jin. All rights reserved.
+// Copyright (C) 2008,2009,2010 by Tom Kao & MISOO Team & Yonghua Jin. All rights reserved.
 // Released under the terms of the GNU Library or Lesser General Public License (LGPL).
 // Author: Tom Kao(中文名：高焕堂)，MISOO团队，Yonghua Jin(中文名：金永华)
 //
@@ -151,7 +151,7 @@ void type##_ctor(type* cthis) {
 
 #define EXTENDS(type)		struct type type
 
-#define SUPER_PTR(cthis, father) ((father*)(&(cthis->father)))
+#define SUPER_PTR(cthis, father) ((father*)(&((cthis)->father)))
 
 #define SUPER_PTR_2(cthis, father, grandfather) \
 	SUPER_PTR(SUPER_PTR(cthis, father), grandfather)
@@ -171,6 +171,6 @@ void type##_ctor(type* cthis) {
 #define SUB_PTR_3(selfptr, self, child, grandchild, greatgrandchild) \
 	SUB_PTR(SUB_PTR_2(selfptr, self, child, grandchild), grandchild, greatgrandchild)
 
-#define INHERIT_FROM(father, cthis, field)	cthis->father.field
+#define INHERIT_FROM(father, cthis, field)	(cthis)->father.field
 
 #endif

--- a/lw_oopc.h
+++ b/lw_oopc.h
@@ -151,7 +151,7 @@ void type##_ctor(type* cthis) {
 
 #define EXTENDS(type)		struct type type
 
-#define SUPER_PTR(cthis, father) ((father*)(&(cthis->father)))
+#define SUPER_PTR(cthis, father) ((father*)(&((cthis)->father)))
 
 #define SUPER_PTR_2(cthis, father, grandfather) \
 	SUPER_PTR(SUPER_PTR(cthis, father), grandfather)
@@ -171,6 +171,6 @@ void type##_ctor(type* cthis) {
 #define SUB_PTR_3(selfptr, self, child, grandchild, greatgrandchild) \
 	SUB_PTR(SUB_PTR_2(selfptr, self, child, grandchild), grandchild, greatgrandchild)
 
-#define INHERIT_FROM(father, cthis, field)	cthis->father.field
+#define INHERIT_FROM(father, cthis, field)	(cthis)->father.field
 
 #endif


### PR DESCRIPTION
例如:
```C
CLASS(Base){};
CLASS(Child){
    EXTENDS(Base);
};
Child child;
```
在访问父类时SUPPER_PTR(&child,Base)会展开成
```C
((Base*)(&(&child->Base)))
```
->的优先级比&高，child->Base是错误的
修改 SUPER_PTR 为 SUPER_PTR(cthis, father) ((father*)(&((cthis)->father)))
同理
修改 INHERIT_FROM为 INHERIT_FROM(father, cthis, field)	(cthis)->father.field